### PR TITLE
Updated kitti dataset placement in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,8 +73,9 @@ datasets
 ├── KITTI  # testing sequences
 │   ├── kitti_seq
 │   │   ├── kitti2015_testings
-│   │   │   ├──000000
-│   │   │   ├── ...
+│   │   │   ├── sequences
+│   │   │   │   ├── 000000
+│   │   │   │   ├── ...
 ```
 
 ## Checkpoints


### PR DESCRIPTION
Updated the README to reflect correct kitti testing sequences structure.
as per
```python
class KITTI(StereoDataset):
    def __init__(self, aug_params=None, root='datasets/KITTI', is_test=False, mode='single_frame', frame_sample_length=4, image_set='training',ddp=False, index_by_scene=False, num_frames=11):
        super(KITTI, self).__init__(aug_params, sparse=True, reader=frame_utils.readDispKITTI, temporal=(mode == 'temporal'), frame_sample_length=frame_sample_length,
                                    is_test=is_test, ddp=ddp, load_flow=False, index_by_scene=index_by_scene)
        assert os.path.exists(root)
        if is_test:
            if mode == 'single_frame':
                raise NotImplementedError
            else:  # temporal
                num_frames = num_frames
                scene_list = sorted(glob(os.path.join(root, image_set, 'sequences', '**')))  # imageset in 'kitti_seq/kitti2012_testings', 'kitti_seq/kitti2015_testings'
                image1_list = []
                image2_list = []
                pose_list = []
                disp_list = []
                for scene in scene_list:
                    image1_list.append(sorted(glob(os.path.join(scene, 'image_2', '*.png')))[:num_frames])
                    image2_list.append(sorted(glob(os.path.join(scene, 'image_3', '*.png')))[:num_frames])
                    pose_path = os.path.join(scene, 'orbslam3_pose.txt')
                    pose_list.append(frame_utils.read_kitti_extrinsic(pose_path)[:num_frames])
                    disp_list.append(scene)  # a fake disp_list, pass the scene path
```